### PR TITLE
Add compute shader renderer setup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,13 @@
-from panda3d.core import loadPrcFileData
+from panda3d.core import (
+    loadPrcFileData,
+    Texture,
+    Shader,
+    ShaderAttrib,
+    LVecBase3i,
+    CardMaker,
+    Mat4,
+    ShaderInput,
+)
 from direct.showbase.ShowBase import ShowBase
 from direct.gui.DirectGui import DirectButton, DirectFrame
 
@@ -13,6 +22,9 @@ class RaymarchApp(ShowBase):
         super().__init__()
         self.setFrameRateMeter(True)
         self.win.set_title("Panda3D Raymarch Placeholder")
+
+        # Setup compute-raymarch rendering
+        self._init_raymarch()
 
         # Setup a simple main menu with placeholder buttons.
         self.menu = DirectFrame(frameColor=(0, 0, 0, 0))
@@ -48,7 +60,52 @@ class RaymarchApp(ShowBase):
         """Placeholder callback for unimplemented menu actions."""
         print("Menu item selected (placeholder)")
 
+    def _init_raymarch(self):
+        """Setup resources for the compute-based ray marcher."""
+        w = self.win.get_x_size()
+        h = self.win.get_y_size()
+        self._create_output_tex(w, h)
+        self.comp_shader = Shader.load_compute("raymarch.comp")
+
+        cm = CardMaker("full")
+        cm.setFrameFullscreenQuad()
+        self.fullscreen_quad = self.render2d.attachNewNode(cm.generate())
+        self.fullscreen_quad.set_shader_off()
+        self.fullscreen_quad.set_texture(self.output_tex)
+
+        self.accept("window-event", self._on_resize)
+        self.taskMgr.add(self._dispatch_compute, "raymarch-dispatch")
+
+    def _create_output_tex(self, w, h):
+        self.output_tex = Texture()
+        self.output_tex.setup_2d_texture(int(w), int(h), Texture.T_float, Texture.F_rgba32)
+        self.output_tex.set_clear_color((0, 0, 0, 1))
+
+    def _on_resize(self, window):
+        if window != self.win:
+            return
+        w = window.get_x_size()
+        h = window.get_y_size()
+        self._create_output_tex(w, h)
+        self.fullscreen_quad.set_texture(self.output_tex)
+
+    def _dispatch_compute(self, task):
+        view_proj = self.cam.get_mat(self.render) * self.camLens.get_projection_mat()
+        inv_view_proj = Mat4(view_proj)
+        inv_view_proj.invert_in_place()
+        sattr = ShaderAttrib.make(self.comp_shader)
+        sattr = sattr.set_shader_input("outputImage", self.output_tex, ShaderInput.AWrite)
+        sattr = sattr.set_shader_input("inv_view_proj", inv_view_proj)
+        sattr = sattr.set_shader_input("camera_pos", self.camera.get_pos())
+        sattr = sattr.set_shader_input("time", globalClock.get_frame_time())
+        groups = LVecBase3i((self.output_tex.get_x_size() + 7) // 8,
+                            (self.output_tex.get_y_size() + 7) // 8,
+                            1)
+        self.graphicsEngine.dispatch_compute(groups, sattr, self.win.get_gsg())
+        return task.cont
+
 
 if __name__ == "__main__":
     app = RaymarchApp()
     app.run()
+


### PR DESCRIPTION
## Summary
- integrate compute shader resources in the Panda3D demo
- display the compute shader output via a full-screen quad
- update window-resize handling and dispatch compute work groups

## Testing
- `python main.py` *(fails: Could not open display)*

------
https://chatgpt.com/codex/tasks/task_e_6849ee1e823083208a60a63a79e39def