### PR TITLE
Add procedural PBR material framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,11 @@ Version 0.1 will:
 4. allow the user to select  one of three procedurally generated materials for world geometry.
 5. light the scene with a dynamic light grid that allow the user to determine the color, spacing of the grid in x/y/z, and spacing offset.
 6. provide a UI with an options menu to configure settings.
+
+## Procedural Materials
+
+Procedural PBR materials are generated at runtime using simplex noise and
+fractional Brownian motion. The `MarbleMaterial` class in `procedural_materials.py`
+produces an albedo and roughness texture that are fed directly into the compute
+shader. Additional materials can subclass `ProceduralMaterial` and implement the
+`generate()` method to produce their own textures.

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from panda3d.core import (
     ShaderInput,
     WindowProperties,
 )
+from procedural_materials import MarbleMaterial
 from direct.showbase.ShowBase import ShowBase
 from direct.gui.DirectGui import DirectButton, DirectFrame
 
@@ -74,6 +75,8 @@ class RaymarchApp(ShowBase):
 
         cm = CardMaker("full")
         cm.setFrameFullscreenQuad()
+        self.material = MarbleMaterial()
+        self.material.generate()
         self.fullscreen_quad = self.render2d.attachNewNode(cm.generate())
         self.fullscreen_quad.set_shader_off()
         self.fullscreen_quad.set_texture(self.output_tex)
@@ -104,6 +107,8 @@ class RaymarchApp(ShowBase):
         sattr = sattr.set_shader_input("camera_pos", self.camera.get_pos())
         sattr = sattr.set_shader_input("time", globalClock.get_frame_time())
         sattr = sattr.set_shader_input("u_color", (1.0, 0.766, 0.336))
+        sattr = sattr.set_shader_input("albedo_tex", self.material.albedo_tex)
+        sattr = sattr.set_shader_input("roughness_tex", self.material.roughness_tex)
         sattr = sattr.set_shader_input("u_roughness", 0.2)
         sattr = sattr.set_shader_input("u_R0", 0.04)
         sattr = sattr.set_shader_input("u_light_dir", (1.0, 1.0, 1.0))

--- a/procedural_materials.py
+++ b/procedural_materials.py
@@ -1,0 +1,62 @@
+from panda3d.core import Texture, PNMImage, SamplerState
+from opensimplex import OpenSimplex
+import math
+
+
+def fbm_noise(noise, x, y, octaves=4, lacunarity=2.0, gain=0.5):
+    value = 0.0
+    amplitude = 1.0
+    frequency = 1.0
+    for _ in range(octaves):
+        value += amplitude * noise.noise2d(x * frequency, y * frequency)
+        frequency *= lacunarity
+        amplitude *= gain
+    return value
+
+
+class ProceduralMaterial:
+    """Base class for procedurally generated PBR materials."""
+
+    def __init__(self, width=256, height=256, seed=0):
+        self.width = width
+        self.height = height
+        self.noise = OpenSimplex(seed)
+        self.albedo_tex = None
+        self.roughness_tex = None
+
+    def generate(self):
+        raise NotImplementedError
+
+
+class MarbleMaterial(ProceduralMaterial):
+    """Simple marble-like material using simplex noise and fBm."""
+
+    def generate(self):
+        img = PNMImage(self.width, self.height)
+        rough_img = PNMImage(self.width, self.height, 1)
+        for y in range(self.height):
+            for x in range(self.width):
+                nx = float(x) / self.width
+                ny = float(y) / self.height
+                n = fbm_noise(self.noise, nx * 5.0, ny * 5.0, octaves=5)
+                n = 0.5 * (n + 1.0)
+                marble = 0.5 + 0.5 * math.sin((nx * 10.0 + n * 2.0) * math.pi)
+                r = 0.8 * marble + 0.2
+                g = 0.8 * marble + 0.2
+                b = 0.8 * marble + 0.25
+                img.set_xel(x, y, r, g, b)
+                rough_img.set_xel(x, y, 0.3 + 0.2 * n)
+
+        tex = Texture()
+        tex.load(img)
+        tex.set_wrap_u(SamplerState.WM_repeat)
+        tex.set_wrap_v(SamplerState.WM_repeat)
+
+        rough = Texture()
+        rough.load(rough_img)
+        rough.set_wrap_u(SamplerState.WM_repeat)
+        rough.set_wrap_v(SamplerState.WM_repeat)
+
+        self.albedo_tex = tex
+        self.roughness_tex = rough
+        return tex, rough

--- a/raymarch.comp
+++ b/raymarch.comp
@@ -14,6 +14,8 @@ uniform float u_R0;          // Reflectance at normal incidence
 uniform vec3 u_light_dir;    // Directional light direction (world space)
 uniform vec3 u_light_color;  // Radiance of the light source
 
+layout(binding = 1) uniform sampler2D albedo_tex;
+layout(binding = 2) uniform sampler2D roughness_tex;
 const int MAX_STEPS = 128;
 const float MAX_DIST = 100.0;
 const float EPSILON = 0.001;
@@ -112,6 +114,16 @@ float GeometrySmith(vec3 N, vec3 V, vec3 L, float k) {
 vec3 FresnelSchlick(float cosTheta, float R0) {
     return vec3(R0) + (vec3(1.0 - R0)) * pow(1.0 - cosTheta, 5.0);
 }
+vec3 sample_albedo(vec3 p) {
+    vec2 uv = p.xz * 0.05;
+    return texture(albedo_tex, uv).rgb;
+}
+
+float sample_roughness(vec3 p) {
+    vec2 uv = p.xz * 0.05;
+    return texture(roughness_tex, uv).r;
+}
+
 
 vec4 shade(vec3 p, vec3 n) {
     vec3 L = normalize(u_light_dir);
@@ -123,8 +135,10 @@ vec4 shade(vec3 p, vec3 n) {
     float NdotH = max(dot(n, H), 0.0);
     float VdotH = max(dot(V, H), 0.0);
 
-    float D = DistributionGGX(n, H, u_roughness);
-    float k = (u_roughness + 1.0) * (u_roughness + 1.0) / 8.0;
+    vec3 base_color = sample_albedo(p);
+    float roughness = sample_roughness(p);
+    float D = DistributionGGX(n, H, roughness);
+    float k = (roughness + 1.0) * (roughness + 1.0) / 8.0;
     float G = GeometrySmith(n, V, L, k);
     vec3 F = FresnelSchlick(VdotH, u_R0);
 
@@ -133,7 +147,7 @@ vec4 shade(vec3 p, vec3 n) {
     vec3 specular = numerator / denominator;
 
     vec3 kd = (vec3(1.0) - F);
-    vec3 diffuse = kd * (u_color / PI);
+    vec3 diffuse = kd * (base_color / PI);
 
     vec3 radiance = u_light_color * NdotL;
     vec3 color = (diffuse + specular) * radiance;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 panda3d>=1.10
+opensimplex>=0.4


### PR DESCRIPTION
## Summary
- create `procedural_materials.py` for simplex/fBm based PBR textures
- generate a marble material example
- expose textures to compute shader and sample them
- load and pass the material textures in `main.py`
- document new capability in README
- add opensimplex to requirements

## Testing
- `python -m py_compile main.py procedural_materials.py`

------
https://chatgpt.com/codex/tasks/task_e_684a0aa195dc8320a129a96be6fd9498