### PR TITLE
Support Panda3D z‑up coords

### DIFF
--- a/raymarch.comp
+++ b/raymarch.comp
@@ -21,6 +21,15 @@ const float MAX_DIST = 100.0;
 const float EPSILON = 0.001;
 const float PI = 3.14159265359;
 
+// Convert Panda3D's Z-up coordinate system to the shader's original Y-up system
+vec3 toShaderCoords(vec3 p) {
+    return vec3(p.x, p.z, p.y);
+}
+
+vec3 fromShaderCoords(vec3 p) {
+    return vec3(p.x, p.z, p.y);
+}
+
 // Signed distance function
 float lattice(vec3 p){
     // Repeat space.
@@ -177,8 +186,8 @@ void main() {
     vec4 near_pt = inv_view_proj * vec4(uv * 2.0 - 1.0, 0.0, 1.0);
     vec4 far_pt = inv_view_proj * vec4(uv * 2.0 - 1.0, 1.0, 1.0);
 
-    vec3 ro = camera_pos;
-    vec3 rd = normalize((far_pt.xyz / far_pt.w) - (near_pt.xyz / near_pt.w));
+    vec3 ro = toShaderCoords(camera_pos);
+    vec3 rd = normalize(toShaderCoords((far_pt.xyz / far_pt.w) - (near_pt.xyz / near_pt.w)));
 
     float t = 0.0;
     float dist = 0.0;
@@ -193,8 +202,10 @@ void main() {
 
     vec4 color = vec4(0.0);
     if (dist < EPSILON) {
-        vec3 pos = ro + rd * t;
-        vec3 n = get_normal(pos);
+        vec3 pos_sdf = ro + rd * t;
+        vec3 n_sdf = get_normal(pos_sdf);
+        vec3 pos = fromShaderCoords(pos_sdf);
+        vec3 n = normalize(fromShaderCoords(n_sdf));
         color = shade(pos, n);
     }
 


### PR DESCRIPTION
## Summary
- update compute shader to work with Panda3D's Z-up system

## Testing
- `python -m py_compile procedural_materials.py`

------
https://chatgpt.com/codex/tasks/task_e_684a9d33ced48320b199569278b2782b