### PR TITLE
Add options submenus with lighting controls

### DIFF
--- a/raymarch.comp
+++ b/raymarch.comp
@@ -12,6 +12,7 @@ uniform vec3 u_color;        // Base color of the material
 uniform float u_roughness;   // Perceptual roughness in [0,1]
 uniform float u_R0;          // Reflectance at normal incidence
 uniform vec3 u_light_spacing; // Spacing of the point light grid
+uniform vec3 u_light_offset;  // Offset of the point light grid
 uniform vec3 u_light_color;   // Radiance/color of each point light
 
 layout(binding = 1) uniform sampler2D albedo_tex;
@@ -140,7 +141,7 @@ vec4 shade(vec3 p, vec3 n) {
     float roughness = sample_roughness(p);
 
     vec3 color = vec3(0.0);
-    vec3 base = floor(p / u_light_spacing + 0.5) * u_light_spacing;
+    vec3 base = floor((p - u_light_offset) / u_light_spacing + 0.5) * u_light_spacing + u_light_offset;
     for(int ix=-1; ix<=1; ++ix){
         for(int iy=-1; iy<=1; ++iy){
             for(int iz=-1; iz<=1; ++iz){


### PR DESCRIPTION
## Summary
- extend main menu with Options screen
- add Lighting submenu with configurable spacing, offset, and color
- store lighting parameters and pass them to the compute shader
- allow reopening the menu with the Escape key
- add light grid offset uniform in compute shader

## Testing
- `python3 -m py_compile main.py`
- `python3 -m py_compile procedural_materials.py`

------
https://chatgpt.com/codex/tasks/task_e_684b5307c5a48320a4b178a75565f082