### PR TITLE
Fix compute shader output texture setup

### DIFF
--- a/main.py
+++ b/main.py
@@ -175,14 +175,16 @@ class MainMenuApp(ShowBase):
         self.output_tex.setup_2d_texture(width, height, Texture.T_float, Texture.F_rgba32)
         self.output_tex.clear_image()
 
-        self.compute_shader = Shader.load_compute("raymarch.comp")
+        self.compute_shader = Shader.load_compute(Shader.SL_GLSL, "raymarch.comp")
         groups_x = (width + 7) // 8
         groups_y = (height + 7) // 8
         self.compute_node = ComputeNode("raymarch")
         self.compute_node.add_dispatch(groups_x, groups_y, 1)
         self.compute_np = self.render.attach_new_node(self.compute_node)
         self.compute_np.set_shader(self.compute_shader)
-        self.compute_np.set_shader_input("outputImage", self.output_tex, write=True)
+        # Provide the texture as a writable image for the compute shader.
+        # Panda3D expects the read/write flags to be passed positionally.
+        self.compute_np.set_shader_input("outputImage", self.output_tex, False, True)
 
         material = MarbleMaterial()
         albedo, rough = material.generate()


### PR DESCRIPTION
## Summary
- ensure compute shader output texture uses positional read/write flags

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684b66197a2083208fd71003fcff6790