### PR TITLE
Fix camera transform for compute shader

### DIFF
--- a/main.py
+++ b/main.py
@@ -210,8 +210,7 @@ class MainMenuApp(ShowBase):
         self.taskMgr.add(self._update_compute, "update-compute")
 
     def _update_compute(self, task):
-        view = Mat4(self.cam.get_mat(self.render))
-        view.invert_in_place()            # world_to_camera
+        view = Mat4(self.cam.get_mat(self.render))  # world_to_camera
         proj = self.camLens.get_projection_mat()
         view_proj = proj * view
         inv_view_proj = Mat4(view_proj)


### PR DESCRIPTION
## Summary
- compute shader expected an inverse view-projection matrix
- `main.py` mistakenly inverted the camera matrix before computing this
- remove the unnecessary inversion

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684b932ff3148320ac8ec7e0f24df8e7