### PR TITLE
Fix view matrix inversion and ray origin

### DIFF
--- a/main.py
+++ b/main.py
@@ -210,7 +210,12 @@ class MainMenuApp(ShowBase):
         self.taskMgr.add(self._update_compute, "update-compute")
 
     def _update_compute(self, task):
-        view = Mat4(self.cam.get_mat(self.render))  # world_to_camera
+        # NodePath.getMat returns the camera-to-world transform. Invert it to
+        # obtain the world-to-camera view matrix. See Panda3D docs:
+        # https://docs.panda3d.org/1.10/python/reference/panda3d.core.NodePath#panda3d.core.NodePath.getMat
+        view = Mat4(self.cam.get_mat(self.render))
+        view.invert_in_place()
+
         proj = self.camLens.get_projection_mat()
         view_proj = proj * view
         inv_view_proj = Mat4(view_proj)
@@ -219,9 +224,9 @@ class MainMenuApp(ShowBase):
         self.compute_np.set_shader_input("camera_pos", self.camera.get_pos(self.render))
         self.compute_np.set_shader_input("time", task.time)
         return task.cont
-
     def _on_launch(self):
         if hasattr(self, "menu_frame"):
+
             self.menu_frame.destroy()
         if hasattr(self, "controller"):
             self.taskMgr.remove("fps-update")

--- a/raymarch.comp
+++ b/raymarch.comp
@@ -187,7 +187,8 @@ void main() {
     vec4 near_pt = inv_view_proj * vec4(uv * 2.0 - 1.0, -1.0, 1.0);
     vec4 far_pt = inv_view_proj * vec4(uv * 2.0 - 1.0, 1.0, 1.0);
 
-    vec3 ro = toShaderCoords(camera_pos);
+    // Rays originate from the near plane as required for orthographic lenses (see docs.gl).
+    vec3 ro = toShaderCoords(near_pt.xyz / near_pt.w);
     vec3 rd = normalize(toShaderCoords((far_pt.xyz / far_pt.w) - (near_pt.xyz / near_pt.w)));
 
     float t = 0.0;


### PR DESCRIPTION
## Summary
- correct view matrix inversion when sending matrices to shader
- start rays at near plane to handle orthographic lenses

## Testing
- `python3 -m py_compile main.py`
- `glslangValidator -S comp raymarch.comp`


------
https://chatgpt.com/codex/tasks/task_e_684b99c78f808320a1ae6d7cb480afa4