### PR TITLE
Align engine and shader coordinate systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A proof-of-concept ray marching program using Panda3D.
 Version 0.1 will:
 
 1. allow users to select an SDF that provides world geometry.
-2. allow users to explore the SDF with WSAD for x and z directions, spacebar and ctrl for y+ and y-, and mouse look. This will require translating the default Pand3D world space, which is z = u/downp, into the Shader's space, which is y= up/down.
+2. allow users to explore the SDF with WSAD for horizontal movement, spacebar and ctrl for vertical movement, and mouse look. The application configures Panda3D to use a Y-up coordinate system so the shader and engine share the same conventions.
 3. utilize full BRDF, PBR, and ray marched shadows.
 4. allow the user to select  one of three procedurally generated materials for world geometry.
 5. light the scene with a dynamic point light grid that is configurable by the user.

--- a/main.py
+++ b/main.py
@@ -1,6 +1,11 @@
 from panda3d.core import loadPrcFileData
 
 # Configure window size before loading ShowBase
+# Use Panda3D's Y-up coordinate system so the shader and engine agree.
+# See Panda3D config variable documentation:
+# https://docs.panda3d.org/1.10/python/programming/configuration/prc-globals
+loadPrcFileData("", "coordinate-system yup-right")
+
 loadPrcFileData('', 'win-size 1024 1024')
 
 from direct.showbase.ShowBase import ShowBase

--- a/raymarch.comp
+++ b/raymarch.comp
@@ -22,13 +22,13 @@ const float MAX_DIST = 100.0;
 const float EPSILON = 0.001;
 const float PI = 3.14159265359;
 
-// Convert Panda3D's Z-up coordinate system to the shader's original Y-up system
+// Panda3D and the compute shader both use Y-up, so these are identity transforms
 vec3 toShaderCoords(vec3 p) {
-    return vec3(p.x, p.z, p.y);
+    return p;
 }
 
 vec3 fromShaderCoords(vec3 p) {
-    return vec3(p.x, p.z, p.y);
+    return p;
 }
 
 // Signed distance function


### PR DESCRIPTION
## Summary
- configure Panda3D to use Y‑up coordinates
- update menu documentation about Y‑up convention
- remove shader coordinate conversion helpers

## Testing
- `python3 -m py_compile main.py`
- `python3 -m py_compile procedural_materials.py`
- `python3 main.py` *(fails: Could not open window)*

------
https://chatgpt.com/codex/tasks/task_e_684baa35d9088320bd1dd24e8d487738