### PR TITLE
Use orthographic camera and clean shader

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Version 0.1 will:
 
 For now, we will import the entire Panda3D library to encourage the use of its built-in functions.
 
+This project uses an `OrthographicLens` for rendering. The Panda3D manual explains how to configure the film size and near/far planes: https://docs.panda3d.org/1.10/python/programming/cameras/orthographic-lenses
+
 ## Procedural Materials
 
 Procedural PBR materials are generated at runtime using simplex noise and

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from panda3d.core import (
     ComputeNode,
     CardMaker,
     Mat4,
+    OrthographicLens,
 )
 
 from procedural_materials import MarbleMaterial
@@ -78,6 +79,11 @@ class MainMenuApp(ShowBase):
 
     def __init__(self):
         super().__init__()
+        lens = OrthographicLens()
+        lens.setFilmSize(20, 20)
+        lens.setNearFar(-1000, 1000)
+        self.cam.node().setLens(lens)
+        self.camLens = lens
         self.light_spacing = Vec3(4.0, 4.0, 4.0)
         self.light_offset = Vec3(0.0, 0.0, 0.0)
         self.light_color = Vec3(1.0, 0.85, 0.8)

--- a/raymarch.comp
+++ b/raymarch.comp
@@ -22,15 +22,6 @@ const float MAX_DIST = 100.0;
 const float EPSILON = 0.001;
 const float PI = 3.14159265359;
 
-// Panda3D and the compute shader both use Y-up, so these are identity transforms
-vec3 toShaderCoords(vec3 p) {
-    return p;
-}
-
-vec3 fromShaderCoords(vec3 p) {
-    return p;
-}
-
 // Signed distance function
 float lattice(vec3 p){
     // Repeat space.
@@ -188,8 +179,8 @@ void main() {
     vec4 far_pt = inv_view_proj * vec4(uv * 2.0 - 1.0, 1.0, 1.0);
 
     // Rays originate from the near plane as required for orthographic lenses (see docs.gl).
-    vec3 ro = toShaderCoords(near_pt.xyz / near_pt.w);
-    vec3 rd = normalize(toShaderCoords((far_pt.xyz / far_pt.w) - (near_pt.xyz / near_pt.w)));
+    vec3 ro = near_pt.xyz / near_pt.w;
+    vec3 rd = normalize((far_pt.xyz / far_pt.w - (near_pt.xyz / near_pt.w)));
 
     float t = 0.0;
     float dist = 0.0;
@@ -206,8 +197,8 @@ void main() {
     if (dist < EPSILON) {
         vec3 pos_sdf = ro + rd * t;
         vec3 n_sdf = get_normal(pos_sdf);
-        vec3 pos = fromShaderCoords(pos_sdf);
-        vec3 n = normalize(fromShaderCoords(n_sdf));
+        vec3 pos = pos_sdf;
+        vec3 n = normalize(n_sdf);
         color = shade(pos, n);
     }
 


### PR DESCRIPTION
## Summary
- set up an `OrthographicLens` for the main camera
- reference Panda3D docs on orthographic lenses
- remove unused coordinate conversion helpers in the compute shader

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684bcffdadbc832080db849d12d6f320