### PR TITLE
Remove environment lighting

### DIFF
--- a/main.py
+++ b/main.py
@@ -97,8 +97,6 @@ class MainMenuApp(ShowBase):
         self.light_color = Vec3(1.0, 0.85, 0.8)
         self._build_menu()
         self.accept("escape", self._build_menu)
-        self.dir_light_dir = Vec3(-0.5, -1.0, -0.6)
-        self.dir_light_color = Vec3(1.0, 0.95, 0.9)
 
     def _build_menu(self):
         if hasattr(self, "menu_frame"):
@@ -191,8 +189,6 @@ class MainMenuApp(ShowBase):
             self.compute_np.set_shader_input("u_light_spacing", self.light_spacing)
             self.compute_np.set_shader_input("u_light_offset", self.light_offset)
             self.compute_np.set_shader_input("u_light_color", self.light_color)
-        self.compute_np.set_shader_input("u_dir_light_dir", self.dir_light_dir)
-        self.compute_np.set_shader_input("u_dir_light_color", self.dir_light_color)
 
 # In main.py, replace the MainMenuApp class's compute methods with these:
 
@@ -220,8 +216,6 @@ class MainMenuApp(ShowBase):
         self.compute_np.set_shader_input("u_light_spacing", self.light_spacing)
         self.compute_np.set_shader_input("u_light_offset", self.light_offset)
         self.compute_np.set_shader_input("u_light_color", self.light_color)
-        self.compute_np.set_shader_input("u_dir_light_dir", self.dir_light_dir)
-        self.compute_np.set_shader_input("u_dir_light_color", self.dir_light_color)
 
         # Set initial values for the new uniforms
         self.compute_np.set_shader_input("camera_pos", self.camera.get_pos(self.render))

--- a/raymarch.comp
+++ b/raymarch.comp
@@ -24,8 +24,6 @@ uniform float time;
 uniform vec3 u_light_spacing;
 uniform vec3 u_light_offset;
 uniform vec3 u_light_color;
-uniform vec3 u_dir_light_dir;
-uniform vec3 u_dir_light_color;
 
 // PBR Material Properties
 layout(binding = 1) uniform sampler2D albedo_tex;
@@ -173,26 +171,7 @@ vec4 calculateColor(vec3 p, vec3 n, vec3 V) {
         }
     }
     
-    // Directional light
-    vec3 Ld = normalize(u_dir_light_dir);
-    float NdotLd = max(dot(n, Ld), 0.0);
-    if(NdotLd > 0.0){
-        float shadow = calcSoftshadow(p + n * SURF_DIST * 2.0, Ld, 0.02, MAX_DIST);
-        if(shadow > 0.0){
-            vec3 Hd = normalize(V + Ld);
-            float NDFd = DistributionGGX(n, Hd, roughness);
-            float Gd = GeometrySmith(n, V, Ld, roughness);
-            vec3 Fd = fresnelSchlick(max(dot(Hd, V), 0.0), F0);
-            vec3 specd = (NDFd * Gd * Fd) / (4.0 * max(dot(n,V),0.0) * NdotLd + 0.001);
-            vec3 kdd = vec3(1.0) - Fd;
-            kdd *= (1.0 - metallic);
-            vec3 diffd = kdd * albedo / PI;
-            Lo += (diffd + specd) * u_dir_light_color * NdotLd * shadow;
-        }
-    }
-    // Ambient term for indirect lighting approximation
-    vec3 ambient = (0.03 * albedo + 0.07 * vec3(0.7, 0.8, 1.0)) * ao;
-    vec3 color = ambient + Lo;
+vec3 color = Lo * ao;
 
     // HDR Tone Mapping and Gamma Correction
     color = color / (color + vec3(1.0));


### PR DESCRIPTION
## Summary
- remove directional light inputs from Python app
- drop directional and ambient lighting from compute shader
- compute shader now only uses the point light grid

## Testing
- `python -m py_compile main.py procedural_materials.py`

------
https://chatgpt.com/codex/tasks/task_e_684c034f1e2883209333a0cd73900020