### PR TITLE
Add procedural 3D noise for non-repeating material

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,6 @@ from panda3d.core import (
     Mat4,
 )
 
-from procedural_materials import MarbleMaterial
 
 class FirstPersonController:
     """Simple FPS camera controller using Panda3D input."""
@@ -194,6 +193,8 @@ class MainMenuApp(ShowBase):
 
     def _setup_compute(self):
         width = self.win.getXSize()
+        # Create the output texture and dispatch compute shader as shown in the Panda3D manual:
+        # https://docs.panda3d.org/1.10/python/programming/shaders/compute-shaders
         height = self.win.getYSize()
         self.output_tex = Texture()
         self.output_tex.setup_2d_texture(width, height, Texture.T_float, Texture.F_rgba32)
@@ -205,13 +206,8 @@ class MainMenuApp(ShowBase):
         self.compute_node = ComputeNode("raymarch")
         self.compute_node.add_dispatch(groups_x, groups_y, 1)
         self.compute_np = self.render.attach_new_node(self.compute_node)
-        self.compute_np.set_shader(self.compute_shader)
         self.compute_np.set_shader_input("outputImage", self.output_tex, False, True)
-
-        material = MarbleMaterial()
-        albedo, rough = material.generate()
-        self.compute_np.set_shader_input("albedo_tex", albedo)
-        self.compute_np.set_shader_input("roughness_tex", rough)
+        self.compute_np.set_shader(self.compute_shader)
         self.compute_np.set_shader_input("u_R0", 0.04)
         self.compute_np.set_shader_input("u_light_spacing", self.light_spacing)
         self.compute_np.set_shader_input("u_light_offset", self.light_offset)

--- a/raymarch.comp
+++ b/raymarch.comp
@@ -26,9 +26,11 @@ uniform vec3 u_light_offset;
 uniform vec3 u_light_color;
 
 // PBR Material Properties
-layout(binding = 1) uniform sampler2D albedo_tex;
-layout(binding = 2) uniform sampler2D roughness_tex;
+// Albedo and roughness are computed procedurally now, leaving only the
+// reflectance parameter. See the GLSL uniform rules in the spec:
+// https://docs.gl/gl4/glUniform
 uniform float u_R0; // Reflectance at normal incidence (typically ~0.04 for dielectrics)
+
 
 //------------------------------------------------------------------------------------------------
 // Constants
@@ -121,12 +123,51 @@ float calculateShadow(vec3 ro, vec3 rd, float max_t) {
     return 1.0;
 }
 
-// In raymarch.comp
+// Value noise based on a simple hash; this avoids repeating patterns.
+float hash3(vec3 p) {
+    return fract(sin(dot(p, vec3(12.9898, 78.233, 37.719))) * 43758.5453);
+}
+
+float noise3(vec3 p) {
+    vec3 i = floor(p);
+    vec3 f = fract(p);
+    vec3 u = f*f*(3.0-2.0*f);
+    float n000 = hash3(i + vec3(0,0,0));
+    float n100 = hash3(i + vec3(1,0,0));
+    float n010 = hash3(i + vec3(0,1,0));
+    float n110 = hash3(i + vec3(1,1,0));
+    float n001 = hash3(i + vec3(0,0,1));
+    float n101 = hash3(i + vec3(1,0,1));
+    float n011 = hash3(i + vec3(0,1,1));
+    float n111 = hash3(i + vec3(1,1,1));
+    float nx00 = mix(n000, n100, u.x);
+    float nx10 = mix(n010, n110, u.x);
+    float nx01 = mix(n001, n101, u.x);
+    float nx11 = mix(n011, n111, u.x);
+    float nxy0 = mix(nx00, nx10, u.y);
+    float nxy1 = mix(nx01, nx11, u.y);
+    return mix(nxy0, nxy1, u.z);
+}
+
+float fbm3(vec3 p) {
+    float v = 0.0;
+    float a = 0.5;
+    for (int i = 0; i < 5; ++i) {
+        v += a * noise3(p);
+        p *= 2.0;
+        a *= 0.5;
+    }
+    return v;
+}
 
 vec4 calculateColor(vec3 p, vec3 n, vec3 V) {
-    // Sample material properties from procedural textures
-    vec3 albedo = texture(albedo_tex, p.xz * 0.05).rgb;
-    float roughness = texture(roughness_tex, p.xz * 0.05).r;
+
+    // Procedural marble based on 3D fBm noise
+    float n = fbm3(p * 0.2);
+    float m = sin(p.y * 0.3 + n * 3.0);
+    vec3 albedo = mix(vec3(0.2, 0.2, 0.25), vec3(0.9, 0.9, 0.95), m);
+    float roughness = 0.3 + 0.2 * n;
+
 
     // PBR properties for a non-metallic surface
     float metallic = 0.0;


### PR DESCRIPTION
## Summary
- remove MarbleMaterial usage and rely on shader-driven noise
- add procedural noise functions in `raymarch.comp`
- sample noise in `calculateColor` for unique texture
- update compute setup code accordingly

## Testing
- `python -m py_compile main.py procedural_materials.py`
- `ruff check .` *(fails: unrecognized subcommand)*


------
https://chatgpt.com/codex/tasks/task_e_684c07bdea908320a1a6259810b098ff