### PR TITLE
Increase raymarch max distance

### DIFF
--- a/raymarch.comp
+++ b/raymarch.comp
@@ -37,7 +37,7 @@ uniform float u_R0; // Reflectance at normal incidence (typically ~0.04 for diel
 //------------------------------------------------------------------------------------------------
 const float PI = 3.14159265359;
 const int   MAX_STEPS = 256;
-const float MAX_DIST = 100.0;
+const float MAX_DIST = 1000.0;
 const float SURF_DIST = 0.0005;
 
 float epsilon(float t) {


### PR DESCRIPTION
## Summary
- extend `MAX_DIST` in compute shader to allow rays to travel farther

## Testing
- `python -m py_compile main.py procedural_materials.py`

------
https://chatgpt.com/codex/tasks/task_e_684cadeb5d048320a38f2ef95a8e9900