### PR TITLE
Center light grid on world origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Version 0.1 will:
 2. allow users to explore the SDF with WSAD for horizontal movement, spacebar and ctrl for vertical movement, and mouse look.
 3. utilize full BRDF, PBR, and ray marched shadows.
 4. provide a default procedurally generated material the is not tiled, but seemingly infinite and non-repeating.
-5. light the scene with an infinite dynamic point light grid whose spacing and offset is configurable by the user.
+5. light the scene with a dynamic point light grid centered on the world origin whose spacing and offset are configurable by the user.
 6. provide a UI with an options menu to configure settings.

--- a/raymarch.comp
+++ b/raymarch.comp
@@ -212,7 +212,12 @@ vec4 calculateColor(vec3 p, vec3 n, vec3 V) {
 
     // Accumulate lighting from a 3x3x3 grid of point lights
     vec3 Lo = vec3(0.0); // Final outgoing radiance
-    vec3 light_grid_base = floor((p - u_light_offset) / u_light_spacing + 0.5) * u_light_spacing + u_light_offset;
+    // Determine the starting point of the light grid relative to the world
+    // origin. Lighting parameters come from Python via shader inputs. See
+    // Panda3D docs on setShaderInput:
+    // https://docs.panda3d.org/1.10/python/programming/shaders/shader-inputs
+    // The grid origin is constant and does not depend on the surface hit point.
+    vec3 light_grid_base = u_light_offset;
 
     for (int ix = -1; ix <= 1; ++ix) {
         for (int iy = -1; iy <= 1; ++iy) {


### PR DESCRIPTION
## Summary
- anchor lighting grid at the world origin rather than the hit position
- update README to describe new lighting placement

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684ce8dadb6c8320b6f8835e6218a135