### PR TITLE
Implement materials settings submenu

### DIFF
--- a/raymarch.comp
+++ b/raymarch.comp
@@ -25,6 +25,15 @@ uniform vec3 u_light_spacing;
 uniform vec3 u_light_offset;
 uniform vec3 u_light_color;
 
+// Procedural material controls. These parameters allow the Python UI to modify
+// the fBm noise used for the marble material. See the GLSL uniform rules:
+// https://docs.gl/gl4/glUniform
+uniform float u_material_scale;   // Overall material scale
+uniform int   u_fbm_octaves;      // Number of fBm layers
+uniform float u_fbm_lacunarity;   // Frequency multiplier per octave
+uniform float u_fbm_gain;         // Amplitude multiplier per octave
+uniform float u_fbm_amplitude;    // Starting amplitude
+
 // PBR Material Properties
 // Albedo and roughness are computed procedurally now, leaving only the
 // reflectance parameter. See the GLSL uniform rules in the spec:
@@ -175,17 +184,16 @@ float snoise(vec3 v){
 }
 
 float fbm3(vec3 p){
-    float v=0.0;
-    float a=0.5;
-    mat3 m3=mat3(0.00,0.80,0.60,-0.80,0.36,-0.48,-0.60,-0.48,0.64);
-    for(int i=0;i<7;i++){
-        v+=a*snoise(p);
-        p=m3*p*2.0;
-        a*=0.5;
+    float v = 0.0;
+    float a = u_fbm_amplitude;
+    mat3 rot = mat3(0.00,0.80,0.60,-0.80,0.36,-0.48,-0.60,-0.48,0.64);
+    for(int i = 0; i < u_fbm_octaves; ++i){
+        v += a * snoise(p);
+        p = rot * p * u_fbm_lacunarity;
+        a *= u_fbm_gain;
     }
     return v;
 }
-
 
 
 vec3 ACESFilm(vec3 x){
@@ -200,8 +208,8 @@ vec3 ACESFilm(vec3 x){
 vec4 calculateColor(vec3 p, vec3 n, vec3 V) {
 
     // Procedural marble based on 3D fBm noise
-    float noiseVal = fbm3(p * 2.0);
-    float m = sin(p.y * 4.0 + noiseVal * 6.0);
+    float noiseVal = fbm3(p * u_material_scale);
+    float m = sin(p.y * u_material_scale * 4.0 + noiseVal * 6.0);
     vec3 albedo = mix(vec3(0.2, 0.2, 0.25), vec3(0.9, 0.9, 0.95), m);
     float roughness = 0.25 + 0.15 * noiseVal;
 


### PR DESCRIPTION
## Summary
- add adjustable material parameters to compute shader
- expose fBm variables in the Settings UI
- update `_on_materials` to open materials menu

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684cf717c7208320a7db0cb5a90117ad