### PR TITLE
Add camera centered lighting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ Version 0.1 will:
 4. provide a default procedurally generated material the is not tiled, but seemingly infinite and non-repeating.
 5. light the scene with a dynamic point light grid centered on the world origin whose spacing and offset are configurable by the user.
 6. provide a UI with an options menu to configure settings.
+
+7. optionally use a camera-centered 2x2x2 light grid via the Lighting menu.

--- a/raymarch.comp
+++ b/raymarch.comp
@@ -24,6 +24,7 @@ uniform float time;
 uniform vec3 u_light_spacing;
 uniform vec3 u_light_offset;
 uniform vec3 u_light_color;
+uniform bool u_use_camera_grid;
 
 // Procedural material controls. These parameters allow the Python UI to modify
 // the fBm noise used for the marble material. See the GLSL uniform rules:
@@ -228,40 +229,72 @@ vec4 calculateColor(vec3 p, vec3 n, vec3 V) {
     // The grid origin is constant and does not depend on the surface hit point.
     vec3 light_grid_base = u_light_offset;
 
-    for (int ix = -1; ix <= 1; ++ix) {
-        for (int iy = -1; iy <= 1; ++iy) {
-            for (int iz = -1; iz <= 1; ++iz) {
-                vec3 light_pos = light_grid_base + vec3(ix, iy, iz) * u_light_spacing;
-                vec3 L = normalize(light_pos - p);
-                float light_dist = length(light_pos - p);
-                float attenuation = 1.0 / (light_dist * light_dist);
-                vec3 radiance = u_light_color * attenuation;
-                vec3 H = normalize(V + L);
-                float NdotL = max(dot(n, L), 0.0);
-                
-                if (NdotL > 0.0) {
-                    float shadow = calculateShadow(p + n * SURF_DIST * 2.0, L, light_dist);
-                    if (shadow > 0.0) {
-                        float NDF = DistributionGGX(n, H, roughness);
-                        float G = GeometrySmith(n, V, L, roughness);
-                        vec3 F = fresnelSchlick(max(dot(H, V), 0.0), F0);
+    
+    if (u_use_camera_grid) {
+        for (int ix = -1; ix <= 1; ix += 2) {
+            for (int iy = -1; iy <= 1; iy += 2) {
+                for (int iz = -1; iz <= 1; iz += 2) {
+                    vec3 light_pos = camera_pos + vec3(ix, iy, iz) * u_light_spacing * 0.5;
+                    vec3 L = normalize(light_pos - p);
+                    float light_dist = length(light_pos - p);
+                    float attenuation = 1.0 / (light_dist * light_dist);
+                    vec3 radiance = u_light_color * attenuation;
+                    vec3 H = normalize(V + L);
+                    float NdotL = max(dot(n, L), 0.0);
 
-                        vec3 spec = (NDF * G * F) / (4.0 * max(dot(n,V),0.0) * NdotL + 0.001);
-                        
-                        // Correct kd calculation for energy conservation
-                        vec3 kd = vec3(1.0) - F;
-                        kd *= (1.0 - metallic);
-                        
-                        // Apply albedo to the diffuse component
-                        vec3 diffuse = kd * albedo / PI;
+                    if (NdotL > 0.0) {
+                        float shadow = calculateShadow(p + n * SURF_DIST * 2.0, L, light_dist);
+                        if (shadow > 0.0) {
+                            float NDF = DistributionGGX(n, H, roughness);
+                            float G = GeometrySmith(n, V, L, roughness);
+                            vec3 F = fresnelSchlick(max(dot(H, V), 0.0), F0);
 
-                        Lo += (diffuse + spec) * radiance * NdotL;
+                            vec3 spec = (NDF * G * F) / (4.0 * max(dot(n,V),0.0) * NdotL + 0.001);
+
+                            vec3 kd = vec3(1.0) - F;
+                            kd *= (1.0 - metallic);
+
+                            vec3 diffuse = kd * albedo / PI;
+
+                            Lo += (diffuse + spec) * radiance * NdotL;
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        for (int ix = -1; ix <= 1; ++ix) {
+            for (int iy = -1; iy <= 1; ++iy) {
+                for (int iz = -1; iz <= 1; ++iz) {
+                    vec3 light_pos = light_grid_base + vec3(ix, iy, iz) * u_light_spacing;
+                    vec3 L = normalize(light_pos - p);
+                    float light_dist = length(light_pos - p);
+                    float attenuation = 1.0 / (light_dist * light_dist);
+                    vec3 radiance = u_light_color * attenuation;
+                    vec3 H = normalize(V + L);
+                    float NdotL = max(dot(n, L), 0.0);
+
+                    if (NdotL > 0.0) {
+                        float shadow = calculateShadow(p + n * SURF_DIST * 2.0, L, light_dist);
+                        if (shadow > 0.0) {
+                            float NDF = DistributionGGX(n, H, roughness);
+                            float G = GeometrySmith(n, V, L, roughness);
+                            vec3 F = fresnelSchlick(max(dot(H, V), 0.0), F0);
+
+                            vec3 spec = (NDF * G * F) / (4.0 * max(dot(n,V),0.0) * NdotL + 0.001);
+
+                            vec3 kd = vec3(1.0) - F;
+                            kd *= (1.0 - metallic);
+
+                            vec3 diffuse = kd * albedo / PI;
+
+                            Lo += (diffuse + spec) * radiance * NdotL;
+                        }
                     }
                 }
             }
         }
     }
-    
 vec3 color = Lo;
 
     // HDR Tone Mapping and Gamma Correction


### PR DESCRIPTION
## Summary
- control lighting grid type with DirectCheckButton
- track state in `MainMenuApp.use_camera_light_grid`
- expose new shader uniform `u_use_camera_grid`
- compute shader chooses between world and camera lighting grids
- document feature in README
- fix toggle to send integer uniform
- improve lighting menu layout

## Testing
- `python -m py_compile main.py`
- `glslangValidator -S comp raymarch.comp`


------
https://chatgpt.com/codex/tasks/task_e_684d0c5c9df883208711d726a09fd04d