### PR TITLE
Fix boolean uniform for camera lighting mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -232,7 +232,7 @@ class MainMenuApp(ShowBase):
     def _toggle_camera_light_grid(self, value):
         self.use_camera_light_grid = bool(value)
         if hasattr(self, "compute_np"):
-            self.compute_np.set_shader_input("u_use_camera_grid", self.use_camera_light_grid)
+            self.compute_np.set_shader_input("u_use_camera_grid", int(self.use_camera_light_grid))
 
 
 
@@ -329,13 +329,11 @@ class MainMenuApp(ShowBase):
         self.compute_np.set_shader_input("u_fbm_lacunarity", self.fbm_lacunarity)
         self.compute_np.set_shader_input("u_fbm_gain", self.fbm_gain)
         self.compute_np.set_shader_input("u_fbm_amplitude", self.fbm_amplitude)
-
-        self.compute_np.set_shader_input("u_use_camera_grid", self.use_camera_light_grid)
+        self.compute_np.set_shader_input("u_use_camera_grid", int(self.use_camera_light_grid))
         # Set initial values for the new uniforms
         self.compute_np.set_shader_input("camera_pos", self.camera.get_pos(self.render))
         self.compute_np.set_shader_input("cam_to_world", self.camera.get_mat(self.render))
         self.compute_np.set_shader_input("proj_mat", self.camLens.get_projection_mat())
-
         cm = CardMaker("fullscreen")
         cm.set_frame_fullscreen_quad()
         card = self.render2d.attach_new_node(cm.generate())
@@ -356,8 +354,8 @@ class MainMenuApp(ShowBase):
         
         # 3. The projection matrix (to extract the FOV)
         self.compute_np.set_shader_input("proj_mat", self.camLens.get_projection_mat())
+        self.compute_np.set_shader_input("u_use_camera_grid", int(self.use_camera_light_grid))
 
-        self.compute_np.set_shader_input("u_use_camera_grid", self.use_camera_light_grid)
         self.compute_np.set_shader_input("time", task.time)
         return task.cont
         

--- a/raymarch.comp
+++ b/raymarch.comp
@@ -24,7 +24,7 @@ uniform float time;
 uniform vec3 u_light_spacing;
 uniform vec3 u_light_offset;
 uniform vec3 u_light_color;
-uniform bool u_use_camera_grid;
+uniform int u_use_camera_grid;
 
 // Procedural material controls. These parameters allow the Python UI to modify
 // the fBm noise used for the marble material. See the GLSL uniform rules:
@@ -230,7 +230,7 @@ vec4 calculateColor(vec3 p, vec3 n, vec3 V) {
     vec3 light_grid_base = u_light_offset;
 
     
-    if (u_use_camera_grid) {
+    if (u_use_camera_grid != 0) {
         for (int ix = -1; ix <= 1; ix += 2) {
             for (int iy = -1; iy <= 1; iy += 2) {
                 for (int iz = -1; iz <= 1; iz += 2) {


### PR DESCRIPTION
## Summary
- adjust uniform type for camera grid toggle to `int`
- ensure shader input uses integer values

## Testing
- `python -m py_compile main.py procedural_materials.py`
- `python - <<'PY'
from panda3d.core import Shader
Shader.load_compute(Shader.SL_GLSL, 'raymarch.comp')
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_684d36c4eab48320ae1184531cf85074