### PR TITLE
Fix camera-centered lighting grid

### DIFF
--- a/raymarch.comp
+++ b/raymarch.comp
@@ -234,7 +234,9 @@ vec4 calculateColor(vec3 p, vec3 n, vec3 V) {
         for (int ix = -1; ix <= 1; ix += 2) {
             for (int iy = -1; iy <= 1; iy += 2) {
                 for (int iz = -1; iz <= 1; iz += 2) {
-                    vec3 light_pos = camera_pos + vec3(ix, iy, iz) * u_light_spacing * 0.5;
+                    // Offset each point light relative to the camera position
+                    // while honoring the user-configurable grid offset.
+                    vec3 light_pos = camera_pos + u_light_offset + vec3(ix, iy, iz) * u_light_spacing * 0.5;
                     vec3 L = normalize(light_pos - p);
                     float light_dist = length(light_pos - p);
                     float attenuation = 1.0 / (light_dist * light_dist);


### PR DESCRIPTION
## Summary
- fix offset when using the camera-centered light grid
  - lights now respect the user configured offset

## Testing
- `python -m py_compile main.py`
- `glslangValidator -S comp -G raymarch.comp` *(fails: non-opaque uniform variables need a layout)*

------
https://chatgpt.com/codex/tasks/task_e_684d39405b8483209c0b0dbcbdd53792