### PR TITLE
Improve diffuse model and Fresnel handling

### DIFF
--- a/raymarch.comp
+++ b/raymarch.comp
@@ -106,7 +106,9 @@ vec3 getNormal(vec3 p) {
 float DistributionGGX(vec3 N, vec3 H, float r) { float a2=r*r*r*r; float nH=max(dot(N,H),0.); return a2/(PI*pow(nH*nH*(a2-1.)+1.,2.)); }
 float GeometrySchlickGGX(float nV, float r) { float k=(r+1.)*(r+1.)/8.; return nV/(nV*(1.-k)+k); }
 float GeometrySmith(vec3 N, vec3 V, vec3 L, float r) { return GeometrySchlickGGX(max(dot(N,V),0.),r)*GeometrySchlickGGX(max(dot(N,L),0.),r); }
-vec3 fresnelSchlick(float c, vec3 F0) { return F0+(vec3(1.)-F0)*pow(clamp(1.-c,0.,1.),5.);}
+float luminance(vec3 c) { return dot(c, vec3(0.2126,0.7152,0.0722)); }
+vec3 fresnelSchlick(float c, vec3 F0) { float F90 = min(1.0, 60.0 * luminance(F0)); return F0 + (vec3(F90) - F0) * pow(clamp(1.0 - c, 0.0, 1.0), 5.0); }
+vec3 orenNayarDiffuse(vec3 albedo, float roughness, vec3 N, vec3 V, vec3 L) { float NL=max(dot(N,L),0.); float NV=max(dot(N,V),0.); float sigma2=roughness*roughness; float A=1.0-0.5*(sigma2/(sigma2+0.33)); float B=0.45*(sigma2/(sigma2+0.09)); float sinThetaL=sqrt(max(0.0,1.0-NL*NL)); float sinThetaV=sqrt(max(0.0,1.0-NV*NV)); float maxCos=0.0; if(sinThetaL>1e-4 && sinThetaV>1e-4){ vec3 Lp=normalize(L-N*NL); vec3 Vp=normalize(V-N*NV); maxCos=max(dot(Lp,Vp),0.0);} float sinAlpha=max(sinThetaL,sinThetaV); float tanBeta=(sinThetaL<sinThetaV)? sinThetaL/max(NL,1e-4): sinThetaV/max(NV,1e-4); return albedo*NL*(A + B*maxCos*sinAlpha*tanBeta)/PI; }
 
 /* Ambient occlusion disabled for now */
 float calcAO(vec3 pos, vec3 nor) { return 1.0; }
@@ -261,9 +263,8 @@ vec4 calculateColor(vec3 p, vec3 n, vec3 V) {
                             vec3 kd = vec3(1.0) - F;
                             kd *= (1.0 - metallic);
 
-                            vec3 diffuse = kd * albedo / PI;
-
-                            Lo += (diffuse + spec) * radiance * NdotL;
+                            vec3 diffuse = kd * orenNayarDiffuse(albedo, roughness, n, V, L);
+                            Lo += diffuse * radiance + spec * radiance * NdotL;
                         }
                     }
                 }
@@ -293,9 +294,9 @@ vec4 calculateColor(vec3 p, vec3 n, vec3 V) {
                             vec3 kd = vec3(1.0) - F;
                             kd *= (1.0 - metallic);
 
-                            vec3 diffuse = kd * albedo / PI;
+                            vec3 diffuse = kd * orenNayarDiffuse(albedo, roughness, n, V, L);
 
-                            Lo += (diffuse + spec) * radiance * NdotL;
+                            Lo += diffuse * radiance + spec * radiance * NdotL;
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- implement Oren-Nayar diffuse
- apply Schüler's Fresnel fix to avoid bright cavities

## Testing
- `python -m py_compile main.py procedural_materials.py`

------
https://chatgpt.com/codex/tasks/task_e_684e158df7b08320ba0dafbaa8e8361f